### PR TITLE
build(demos/astro-capsize-font-fallbacks): 🧱 update dependencies

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,24 +1,58 @@
+pnpm --filter astro-capsize-font-fallbacks install
 pnpm --filter astro-capsize-font-fallbacks check
+
+pnpm --filter astro-contact-form install
 pnpm --filter astro-contact-form check
+
 pnpm --filter astro-contact-form check:svelte
 pnpm --filter astro-cookies-api check:svelte
+
+pnpm --filter astro-js-404-page install
 pnpm --filter astro-js-404-page check
+
+pnpm --filter astro-js-favicon install
 pnpm --filter astro-js-favicon check
-# pnpm --filter astro-js-location-map check
+
+pnpm --filter astro-js-location-map install
+pnpm --filter astro-js-location-map check
+
 pnpm --filter astro-js-location-map check:svelte
+
+pnpm --filter astro-markdoc install
 pnpm --filter astro-markdoc check
+
+pnpm --filter astro-js-middleware install
 pnpm --filter astro-js-middleware check
+
+pnpm --filter astro-js-non-html-route install
 pnpm --filter astro-js-non-html-route check
+
+pnpm --filter astro-js-sass-styling install
 pnpm --filter astro-js-sass-styling check
+
 # pnpm --filter astro-mux-player check
+
+pnpm --filter astro-postcss install
 pnpm --filter astro-postcss check
+
+pnpm --filter astro-prerender-comment-form install
 pnpm --filter astro-prerender-comment-form check
+
+pnpm --filter astro-qr-code-generator install
 pnpm --filter astro-qr-code-generator check
+
 # pnpm --filter astro-related-content check
 # pnpm --filter astro-scroll-to-anchor check
 # pnpm --filter astro-self-hosted-fonts check
+
+pnpm --filter astro-vanilla-extract install
 pnpm --filter astro-vanilla-extract check
+
 # pnpm --filter getting-started-astro check
+
+pnpm --filter temporal-api-duration install
 pnpm --filter temporal-api-duration check
+
+pnpm --filter temporal-api-time-zones install
 pnpm --filter temporal-api-time-zones check
 

--- a/demos/astro-capsize-font-fallbacks/.stylelintrc.json
+++ b/demos/astro-capsize-font-fallbacks/.stylelintrc.json
@@ -1,24 +1,24 @@
 {
-	"extends": "stylelint-config-recommended",
-	"rules": {
-		"color-named": "never",
-		"font-family-name-quotes": "always-where-required",
-		"font-weight-notation": "named-where-possible",
-		"function-url-no-scheme-relative": true,
-		"function-url-quotes": "always",
-		"value-keyword-case": "lower",
-		"unit-disallowed-list": [],
-		"no-descending-specificity": true,
-		"no-duplicate-selectors": true,
-		"font-family-no-missing-generic-family-keyword": null,
-		"property-no-unknown": [
-			true,
-			{
-				"ignoreProperties": ["/^lost-/"]
-			}
-		]
-	},
-	"ignoreFiles": ["node_modules/*", "src/assets/**", "build/**"],
-	"defaultSeverity": "error",
-	"customSyntax": "postcss-html"
+  "extends": "stylelint-config-recommended",
+  "rules": {
+    "color-named": "never",
+    "font-family-name-quotes": "always-where-required",
+    "font-weight-notation": "named-where-possible",
+    "function-url-no-scheme-relative": true,
+    "function-url-quotes": "always",
+    "value-keyword-case": "lower",
+    "unit-disallowed-list": [],
+    "no-descending-specificity": true,
+    "no-duplicate-selectors": true,
+    "font-family-no-missing-generic-family-keyword": null,
+    "property-no-unknown": [
+      true,
+      {
+        "ignoreProperties": ["/^lost-/"]
+      }
+    ]
+  },
+  "ignoreFiles": ["node_modules/*", "src/assets/**", "build/**"],
+  "defaultSeverity": "error",
+  "customSyntax": "postcss-html"
 }

--- a/demos/astro-capsize-font-fallbacks/.vscode/extensions.json
+++ b/demos/astro-capsize-font-fallbacks/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-	"recommendations": ["astro-build.astro-vscode"],
-	"unwantedRecommendations": []
+  "recommendations": ["astro-build.astro-vscode"],
+  "unwantedRecommendations": []
 }

--- a/demos/astro-capsize-font-fallbacks/.vscode/launch.json
+++ b/demos/astro-capsize-font-fallbacks/.vscode/launch.json
@@ -1,11 +1,11 @@
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"command": "./node_modules/.bin/astro dev",
-			"name": "Development server",
-			"request": "launch",
-			"type": "node-terminal"
-		}
-	]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "command": "./node_modules/.bin/astro dev",
+      "name": "Development server",
+      "request": "launch",
+      "type": "node-terminal"
+    }
+  ]
 }

--- a/demos/astro-capsize-font-fallbacks/astro.config.mjs
+++ b/demos/astro-capsize-font-fallbacks/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({});

--- a/demos/astro-capsize-font-fallbacks/capsize-font-fallbacks.ts
+++ b/demos/astro-capsize-font-fallbacks/capsize-font-fallbacks.ts
@@ -1,12 +1,12 @@
-import { createFontStack } from '@capsizecss/core';
-import arial from '@capsizecss/metrics/arial';
-import openSans from '@capsizecss/metrics/openSans';
-import roboto from '@capsizecss/metrics/roboto';
-import { writeFileSync } from 'node:fs';
-import path from 'node:path';
+import { createFontStack } from "@capsizecss/core";
+import arial from "@capsizecss/metrics/arial";
+import openSans from "@capsizecss/metrics/openSans";
+import roboto from "@capsizecss/metrics/roboto";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
 
 const __dirname = path.resolve();
-const outputPath = path.join(__dirname, 'src/styles/font-fallbacks.css');
+const outputPath = path.join(__dirname, "src/styles/font-fallbacks.css");
 
 const { fontFaces, fontFamily } = createFontStack([openSans, arial, roboto]);
 

--- a/demos/astro-capsize-font-fallbacks/package.json
+++ b/demos/astro-capsize-font-fallbacks/package.json
@@ -1,30 +1,30 @@
 {
-	"name": "astro-capsize-font-fallbacks",
-	"type": "module",
-	"version": "0.0.1",
-	"private": true,
-	"scripts": {
-		"dev": "astro dev",
-		"start": "astro dev",
-		"build": "astro telemetry disable && astro build",
-		"preview": "astro preview",
-		"astro": "astro",
-		"check": "astro check --fail-on-warnings",
-		"format": "prettier --write --plugin=prettier-plugin-astro .",
-		"lint:css": "stylelint \"src/**/*.{css,astro}\""
-	},
-	"dependencies": {
-		"@capsizecss/core": "^4.1.2",
-		"@capsizecss/metrics": "^3.4.0",
-		"astro": "^5.0.0",
-		"postcss-html": "^1.7.0",
-		"stylelint": "^16.11.0",
-		"stylelint-config-recommended": "^14.0.1",
-		"stylelint-config-standard": "^36.0.1"
-	},
-	"devDependencies": {
-		"@astrojs/check": "^0.9.4",
-		"typescript": "^5.7.2",
-		"vite-node": "^2.1.8"
-	}
+  "name": "astro-capsize-font-fallbacks",
+  "type": "module",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro telemetry disable && astro build",
+    "preview": "astro preview",
+    "astro": "astro",
+    "check": "astro check --fail-on-warnings",
+    "format": "prettier --write --plugin=prettier-plugin-astro .",
+    "lint:css": "stylelint \"src/**/*.{css,astro}\""
+  },
+  "dependencies": {
+    "@capsizecss/core": "^4.1.2",
+    "@capsizecss/metrics": "^3.4.0",
+    "astro": "^5.1.9",
+    "postcss-html": "^1.8.0",
+    "stylelint": "^16.13.2",
+    "stylelint-config-recommended": "^15.0.0",
+    "stylelint-config-standard": "^37.0.0"
+  },
+  "devDependencies": {
+    "@astrojs/check": "^0.9.4",
+    "typescript": "^5.7.3",
+    "vite-node": "^3.0.4"
+  }
 }

--- a/demos/astro-capsize-font-fallbacks/public/manifest.webmanifest
+++ b/demos/astro-capsize-font-fallbacks/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-	"icons": [
-		{ "src": "/icon-192.png", "type": "image/png", "sizes": "192x192" },
-		{ "src": "/icon-512.png", "type": "image/png", "sizes": "512x512" }
-	]
+  "icons": [
+    { "src": "/icon-192.png", "type": "image/png", "sizes": "192x192" },
+    { "src": "/icon-512.png", "type": "image/png", "sizes": "512x512" }
+  ]
 }

--- a/demos/astro-capsize-font-fallbacks/sandbox.config.json
+++ b/demos/astro-capsize-font-fallbacks/sandbox.config.json
@@ -1,11 +1,11 @@
 {
-	"infiniteLoopProtection": true,
-	"hardReloadOnChange": false,
-	"view": "browser",
-	"template": "node",
-	"container": {
-		"port": 4321,
-		"startScript": "start",
-		"node": "20"
-	}
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "template": "node",
+  "container": {
+    "port": 4321,
+    "startScript": "start",
+    "node": "20"
+  }
 }

--- a/demos/astro-capsize-font-fallbacks/src/pages/index.astro
+++ b/demos/astro-capsize-font-fallbacks/src/pages/index.astro
@@ -1,69 +1,69 @@
 ---
-import '~styles/fonts.css';
-import '~styles/global.css';
+import "~styles/fonts.css";
+import "~styles/global.css";
 
-import '~styles/font-fallbacks.css';
+import "~styles/font-fallbacks.css";
 ---
 
 <html lang="en-GB">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="/favicon.ico" sizes="any" />
-		<link rel="icon" href="/icon.svg" type="image/svg+xml" />
-		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-		<link rel="manifest" href="/manifest.webmanifest" />
-		<meta name="viewport" content="width=device-width" />
-		<title>Astro Capsize Font Fallbacks</title>
-		<meta
-			name="description"
-			content="Astro Font Fallbacks ☄️ how you can use Capsize to reduce layout shift from font swapping when optimizing your site for 🧑🏽 user experience."
-		/>
-	</head>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Astro Capsize Font Fallbacks</title>
+    <meta
+      name="description"
+      content="Astro Font Fallbacks ☄️ how you can use Capsize to reduce layout shift from font swapping when optimizing your site for 🧑🏽 user experience."
+    />
+  </head>
 
-	<body>
-		<main class="container">
-			<h1>🌟 Twinkle, Twinkle, Little Star</h1>
-			<p>
-				Twinkle, twinkle, little star,<br />
-				How I wonder what you are! <br />
-				Up above the world so high, <br />
-				Like a diamond in the sky.
-			</p>
-			<p>
-				When the blazing sun is gone, <br />
-				When he nothing shines upon,<br />
-				Then you show your little light,<br />
-				Twinkle, twinkle, all the night. <br />
-			</p>
-			<p>
-				Then the trav'ller in the dark, <br />
-				Thanks you for your tiny spark, <br />
-				He could not see which way to go, <br />
-				If you did not twinkle so.
-			</p>
-			<p>
-				In the dark blue sky you keep, <br />
-				And often thro' my curtains peep, <br />
-				For you never shut your eye, <br />
-				Till the sun is in the sky. <br />
-			</p>
-			<p>
-				'Tis your bright and tiny spark, <br />
-				Lights the trav'ller in the dark, <br />
-				Tho' I know not what you are, <br />
-				Twinkle, twinkle, little star.
-			</p>
-		</main>
-		<style>
-			.container {
-				display: grid;
-				place-content: center;
-				min-height: 100vh;
-				width: 24rem;
-				max-width: 100%;
-				padding-block: var(--spacing-8);
-				margin-inline: auto;
-			}
-		</style>
-	</body>
+  <body>
+    <main class="container">
+      <h1>🌟 Twinkle, Twinkle, Little Star</h1>
+      <p>
+        Twinkle, twinkle, little star,<br />
+        How I wonder what you are! <br />
+        Up above the world so high, <br />
+        Like a diamond in the sky.
+      </p>
+      <p>
+        When the blazing sun is gone, <br />
+        When he nothing shines upon,<br />
+        Then you show your little light,<br />
+        Twinkle, twinkle, all the night. <br />
+      </p>
+      <p>
+        Then the trav'ller in the dark, <br />
+        Thanks you for your tiny spark, <br />
+        He could not see which way to go, <br />
+        If you did not twinkle so.
+      </p>
+      <p>
+        In the dark blue sky you keep, <br />
+        And often thro' my curtains peep, <br />
+        For you never shut your eye, <br />
+        Till the sun is in the sky. <br />
+      </p>
+      <p>
+        'Tis your bright and tiny spark, <br />
+        Lights the trav'ller in the dark, <br />
+        Tho' I know not what you are, <br />
+        Twinkle, twinkle, little star.
+      </p>
+    </main>
+    <style>
+      .container {
+        display: grid;
+        place-content: center;
+        min-height: 100vh;
+        width: 24rem;
+        max-width: 100%;
+        padding-block: var(--spacing-8);
+        margin-inline: auto;
+      }
+    </style>
+  </body>
 </html>

--- a/demos/astro-capsize-font-fallbacks/src/pages/long-paragraph.astro
+++ b/demos/astro-capsize-font-fallbacks/src/pages/long-paragraph.astro
@@ -1,48 +1,50 @@
 ---
-import '~styles/fonts.css';
-import '~styles/global.css';
+import "~styles/fonts.css";
+import "~styles/global.css";
 
-import '~styles/font-fallbacks.css';
+import "~styles/font-fallbacks.css";
 ---
 
 <html lang="en-GB">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="/favicon.ico" sizes="any" />
-		<link rel="icon" href="/icon.svg" type="image/svg+xml" />
-		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-		<link rel="manifest" href="/manifest.webmanifest" />
-		<meta name="viewport" content="width=device-width" />
-		<title>Astro Capsize Font Fallbacks</title>
-		<meta
-			name="description"
-			content="Astro Font Fallbacks ☄️ how you can use Capsize to reduce layout shift from font swapping when optimizing your site for 🧑🏽 user experience."
-		/>
-	</head>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Astro Capsize Font Fallbacks</title>
+    <meta
+      name="description"
+      content="Astro Font Fallbacks ☄️ how you can use Capsize to reduce layout shift from font swapping when optimizing your site for 🧑🏽 user experience."
+    />
+  </head>
 
-	<body>
-		<main class="container">
-			<h1>🌟 Twinkle, Twinkle, Little Star</h1>
-			<p>
-				Twinkle, twinkle, little star, How I wonder what you are! Up above the world so high, Like a
-				diamond in the sky. When the blazing sun is gone, When he nothing shines upon, Then you show
-				your little light, Twinkle, twinkle, all the night. Then the trav'ller in the dark, Thanks
-				you for your tiny spark, He could not see which way to go, If you did not twinkle so. In the
-				dark blue sky you keep, And often thro' my curtains peep, For you never shut your eye, Till
-				the sun is in the sky. 'Tis your bright and tiny spark, Lights the trav'ller in the dark,
-				Tho' I know not what you are, Twinkle, twinkle, little star.
-			</p>
-		</main>
-		<style>
-			.container {
-				display: grid;
-				place-content: center;
-				min-height: 100vh;
-				width: 24rem;
-				max-width: 100%;
-				padding-block: var(--spacing-8);
-				margin-inline: auto;
-			}
-		</style>
-	</body>
+  <body>
+    <main class="container">
+      <h1>🌟 Twinkle, Twinkle, Little Star</h1>
+      <p>
+        Twinkle, twinkle, little star, How I wonder what you are! Up above the
+        world so high, Like a diamond in the sky. When the blazing sun is gone,
+        When he nothing shines upon, Then you show your little light, Twinkle,
+        twinkle, all the night. Then the trav'ller in the dark, Thanks you for
+        your tiny spark, He could not see which way to go, If you did not
+        twinkle so. In the dark blue sky you keep, And often thro' my curtains
+        peep, For you never shut your eye, Till the sun is in the sky. 'Tis your
+        bright and tiny spark, Lights the trav'ller in the dark, Tho' I know not
+        what you are, Twinkle, twinkle, little star.
+      </p>
+    </main>
+    <style>
+      .container {
+        display: grid;
+        place-content: center;
+        min-height: 100vh;
+        width: 24rem;
+        max-width: 100%;
+        padding-block: var(--spacing-8);
+        margin-inline: auto;
+      }
+    </style>
+  </body>
 </html>

--- a/demos/astro-capsize-font-fallbacks/src/styles/font-fallbacks.css
+++ b/demos/astro-capsize-font-fallbacks/src/styles/font-fallbacks.css
@@ -1,20 +1,21 @@
 /* This file is generated using capsize. Run `vite-node capsize-font-fallbacks.ts` to refresh. */
 
 :root {
-	--font-family: 'Open Sans', 'Open Sans Fallback: Arial', 'Open Sans Fallback: Roboto', sans-serif;
+  --font-family: "Open Sans", "Open Sans Fallback: Arial",
+    "Open Sans Fallback: Roboto", sans-serif;
 }
 
 @font-face {
-	font-family: 'Open Sans Fallback: Arial';
-	src: local('Arial');
-	ascent-override: 101.1768%;
-	descent-override: 27.7323%;
-	size-adjust: 105.6416%;
+  font-family: "Open Sans Fallback: Arial";
+  src: local("Arial");
+  ascent-override: 101.1768%;
+  descent-override: 27.7323%;
+  size-adjust: 105.6416%;
 }
 @font-face {
-	font-family: 'Open Sans Fallback: Roboto';
-	src: local('Roboto');
-	ascent-override: 101.2887%;
-	descent-override: 27.763%;
-	size-adjust: 105.5249%;
+  font-family: "Open Sans Fallback: Roboto";
+  src: local("Roboto");
+  ascent-override: 101.2887%;
+  descent-override: 27.763%;
+  size-adjust: 105.5249%;
 }

--- a/demos/astro-capsize-font-fallbacks/src/styles/fonts.css
+++ b/demos/astro-capsize-font-fallbacks/src/styles/fonts.css
@@ -1,23 +1,23 @@
 /* open-sans-regular - latin */
 @font-face {
-	font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-	font-family: 'Open Sans';
-	font-style: normal;
-	font-weight: 400;
-	src:
-		url('/fonts/open-sans-v35-latin-regular.woff2') format('woff2'),
-		/* Chrome 36+, Opera 23+, Firefox 39+ */ url('/fonts/open-sans-v35-latin-regular.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: "Open Sans";
+  font-style: normal;
+  font-weight: 400;
+  src:
+    url("/fonts/open-sans-v35-latin-regular.woff2") format("woff2"),
+    /* Chrome 36+, Opera 23+, Firefox 39+ */
+      url("/fonts/open-sans-v35-latin-regular.woff") format("woff"); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* open-sans-700 - latin */
 @font-face {
-	font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-	font-family: 'Open Sans';
-	font-style: normal;
-	font-weight: 700;
-	src:
-		url('/fonts/open-sans-v35-latin-700.woff2') format('woff2'),
-		/* Chrome 36+, Opera 23+, Firefox 39+ */ url('/fonts/open-sans-v35-latin-700.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: "Open Sans";
+  font-style: normal;
+  font-weight: 700;
+  src:
+    url("/fonts/open-sans-v35-latin-700.woff2") format("woff2"),
+    /* Chrome 36+, Opera 23+, Firefox 39+ */
+      url("/fonts/open-sans-v35-latin-700.woff") format("woff"); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }

--- a/demos/astro-capsize-font-fallbacks/src/styles/global.css
+++ b/demos/astro-capsize-font-fallbacks/src/styles/global.css
@@ -1,47 +1,48 @@
 :root {
-	--spacing-0: 0;
-	--spacing-2: 0.5rem;
-	--spacing-4: 1rem;
-	--spacing-6: 1.5rem;
-	--spacing-12: 3rem;
-	--spacing-16: 4rem;
+  --spacing-0: 0;
+  --spacing-2: 0.5rem;
+  --spacing-4: 1rem;
+  --spacing-6: 1.5rem;
+  --spacing-12: 3rem;
+  --spacing-16: 4rem;
 
-	--font-size-root: 16px;
-	--font-size-2: 1.25rem;
-	--font-size-4: 1.953rem;
+  --font-size-root: 16px;
+  --font-size-2: 1.25rem;
+  --font-size-4: 1.953rem;
 
-	--font-weight-normal: 400;
-	--font-weight-bold: 700;
+  --font-weight-normal: 400;
+  --font-weight-bold: 700;
 
-	--max-width-full: 100%;
-	--max-width-wrapper: 64rem;
+  --max-width-full: 100%;
+  --max-width-wrapper: 64rem;
 
-	--line-height-relaxed: 1.75;
+  --line-height-relaxed: 1.75;
 
-	--colour-dark: hsl(225 5% 17%); /* shark */
-	--colour-theme: hsl(39 92% 59%); /* saffron */
+  --colour-dark: hsl(225 5% 17%); /* shark */
+  --colour-theme: hsl(39 92% 59%); /* saffron */
 
-	--font-family: 'Open Sans', sans-serif;
+  --font-family: "Open Sans", sans-serif;
 }
 
 *,
 :after,
 :before {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 body {
-	font: var(--font-weight-normal) var(--font-size-2) / var(--line-height-relaxed) var(--font-family);
-	color: var(--colour-theme);
-	background: var(--colour-dark);
+  font: var(--font-weight-normal) var(--font-size-2) /
+    var(--line-height-relaxed) var(--font-family);
+  color: var(--colour-theme);
+  background: var(--colour-dark);
 }
 
 h1 {
-	font-size: var(--font-size-4);
-	margin-block: var(--spacing-12) var(--spacing-6);
+  font-size: var(--font-size-4);
+  margin-block: var(--spacing-12) var(--spacing-6);
 }
 
 p {
-	margin-block: var(--spacing-0) var(--spacing-6);
-	line-height: var(--line-height-relaxed);
+  margin-block: var(--spacing-0) var(--spacing-6);
+  line-height: var(--line-height-relaxed);
 }

--- a/demos/astro-capsize-font-fallbacks/tsconfig.json
+++ b/demos/astro-capsize-font-fallbacks/tsconfig.json
@@ -1,9 +1,9 @@
 {
-	"compilerOptions": {
-		"baseUrl": ".",
-		"paths": {
-			"~*": ["src/*"]
-		}
-	},
-	"extends": "astro/tsconfigs/base"
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~*": ["src/*"]
+    }
+  },
+  "extends": "astro/tsconfigs/base"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,30 +43,30 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       astro:
-        specifier: ^5.0.0
-        version: 5.0.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        specifier: ^5.1.9
+        version: 5.1.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
       postcss-html:
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^1.8.0
+        version: 1.8.0
       stylelint:
-        specifier: ^16.11.0
-        version: 16.11.0(typescript@5.7.2)
+        specifier: ^16.13.2
+        version: 16.13.2(typescript@5.7.3)
       stylelint-config-recommended:
-        specifier: ^14.0.1
-        version: 14.0.1(stylelint@16.11.0(typescript@5.7.2))
+        specifier: ^15.0.0
+        version: 15.0.0(stylelint@16.13.2(typescript@5.7.3))
       stylelint-config-standard:
-        specifier: ^36.0.1
-        version: 36.0.1(stylelint@16.11.0(typescript@5.7.2))
+        specifier: ^37.0.0
+        version: 37.0.0(stylelint@16.13.2(typescript@5.7.3))
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
-        version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.2)
+        version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.3)
       typescript:
-        specifier: ^5.7.2
-        version: 5.7.2
+        specifier: ^5.7.3
+        version: 5.7.3
       vite-node:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
 
   demos/astro-contact-form:
     dependencies:
@@ -79,10 +79,10 @@ importers:
     devDependencies:
       '@astrojs/svelte':
         specifier: ^5.7.3
-        version: 5.7.3(astro@4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2))(svelte@4.2.19)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0))
+        version: 5.7.3(astro@4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2))(svelte@4.2.19)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0))
       astro:
         specifier: ^4.16.16
-        version: 4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)
+        version: 4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)
       axios:
         specifier: ^1.7.9
         version: 1.7.9
@@ -124,10 +124,10 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.2)
       '@astrojs/svelte':
         specifier: ^7.0.1
-        version: 7.0.1(@types/node@22.10.6)(astro@5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.7.1)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 7.0.1(@types/node@22.10.6)(astro@5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.7.1)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       astro:
         specifier: ^5.0.3
-        version: 5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -164,7 +164,7 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.2)
       astro:
         specifier: ^5.0.3
-        version: 5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -201,7 +201,7 @@ importers:
     devDependencies:
       astro:
         specifier: 5.0.4
-        version: 5.0.4(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.0.4(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -216,13 +216,13 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.2)
       '@astrojs/svelte':
         specifier: ^7.0.1
-        version: 7.0.1(@types/node@22.10.6)(astro@5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.14.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 7.0.1(@types/node@22.10.6)(astro@5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.14.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       '@types/leaflet':
         specifier: ^1.9.15
         version: 1.9.15
       astro:
         specifier: ^5.0.5
-        version: 5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -261,10 +261,10 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: ^12.1.0
-        version: 12.1.0(@types/node@22.10.6)(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
+        version: 12.1.0(@types/node@22.10.6)(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       astro:
         specifier: ^5.0.9
-        version: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.3
@@ -301,7 +301,7 @@ importers:
         version: 0.13.7
       astro:
         specifier: ^5.0.9
-        version: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       blob-stream:
         specifier: ^0.1.3
         version: 0.1.3
@@ -353,7 +353,7 @@ importers:
         version: 4.1.1(@types/node@22.10.6)(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(jiti@2.4.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       '@astrojs/svelte':
         specifier: ^7.0.1
-        version: 7.0.1(@types/node@22.10.6)(astro@5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.15.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 7.0.1(@types/node@22.10.6)(astro@5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.15.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       '@types/react':
         specifier: ^19.0.2
         version: 19.0.2
@@ -362,7 +362,7 @@ importers:
         version: 19.0.2(@types/react@19.0.2)
       astro:
         specifier: 5.1.0
-        version: 5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -416,7 +416,7 @@ importers:
         version: 4.1.2(@types/node@22.10.6)(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(jiti@2.4.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       '@astrojs/svelte':
         specifier: ^7.0.2
-        version: 7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.15.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.15.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       '@babel/core':
         specifier: ^7.26.0
         version: 7.26.0
@@ -428,7 +428,7 @@ importers:
         version: 19.0.2(@types/react@19.0.2)
       astro:
         specifier: 5.1.1
-        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -476,13 +476,13 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.2)
       '@astrojs/markdoc':
         specifier: ^0.12.4
-        version: 0.12.4(@types/react@19.0.2)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(react@19.0.0)
+        version: 0.12.4(@types/react@19.0.2)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(react@19.0.0)
       '@wooorm/starry-night':
         specifier: ^3.5.0
         version: 3.5.0
       astro:
         specifier: ^5.1.1
-        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       hast-util-to-html:
         specifier: ^9.0.4
         version: 9.0.4
@@ -534,7 +534,7 @@ importers:
         version: 0.24.2
       astro:
         specifier: ^5.1.1
-        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -573,7 +573,7 @@ importers:
         version: 3.4.0
       astro:
         specifier: ^5.1.1
-        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       postcss-html:
         specifier: ^1.7.0
         version: 1.7.0
@@ -607,13 +607,13 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: ^12.1.0
-        version: 12.1.0(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
+        version: 12.1.0(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       '@astrojs/svelte':
         specifier: ^7.0.2
-        version: 7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.16.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.16.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       astro:
         specifier: ^5.1.1
-        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       stylelint:
         specifier: ^16.12.0
         version: 16.12.0(typescript@5.7.2)
@@ -653,13 +653,13 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.2)
       '@astrojs/netlify':
         specifier: ^6.0.1
-        version: 6.0.1(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
+        version: 6.0.1(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       '@astrojs/svelte':
         specifier: ^7.0.2
-        version: 7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.16.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.16.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       astro:
         specifier: ^5.1.1
-        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       svelte:
         specifier: ^5.16.0
         version: 5.16.0
@@ -696,13 +696,13 @@ importers:
         version: 4.0.10
       '@astrojs/svelte':
         specifier: ^7.0.2
-        version: 7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.16.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.16.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       '@rodneylab/picpack':
         specifier: ^0.1.1
         version: 0.1.1
       astro:
         specifier: ^5.1.1
-        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       stylelint:
         specifier: ^16.13.2
         version: 16.13.2(typescript@5.7.2)
@@ -730,7 +730,7 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.2)
       astro:
         specifier: ~5.1.2
-        version: 5.1.2(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.2(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       astro-icon:
         specifier: ^1.1.5
         version: 1.1.5
@@ -769,7 +769,7 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.2)
       astro:
         specifier: ~5.1.3
-        version: 5.1.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+        version: 5.1.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -811,7 +811,7 @@ importers:
         version: 4.0.1(@babel/core@7.26.0)(@types/node@22.10.6)(jiti@2.4.1)(preact@10.25.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       '@astrojs/svelte':
         specifier: ^7.0.3
-        version: 7.0.3(@types/node@22.10.6)(astro@4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.17.3)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 7.0.3(@types/node@22.10.6)(astro@4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.17.3)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
       preact:
         specifier: ^10.25.4
         version: 10.25.4
@@ -830,7 +830,7 @@ importers:
         version: 4.0.19(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(vite@6.0.7(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
       astro:
         specifier: ~4.16.17
-        version: 4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)
+        version: 4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)
       commitlint:
         specifier: ^19.6.1
         version: 19.6.1(@types/node@22.10.6)(typescript@5.7.3)
@@ -851,7 +851,7 @@ importers:
         version: 6.0.7(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       vite-imagetools:
         specifier: ^7.0.5
-        version: 7.0.5(rollup@4.27.4)
+        version: 7.0.5(rollup@4.31.0)
 
   demos/getting-started-astro:
     devDependencies:
@@ -863,7 +863,7 @@ importers:
         version: 4.1.4(@types/node@22.10.6)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(jiti@2.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       '@astrojs/svelte':
         specifier: ^7.0.3
-        version: 7.0.3(@types/node@22.10.6)(astro@5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.17.4)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 7.0.3(@types/node@22.10.6)(astro@5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.17.4)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
       '@babel/core':
         specifier: ^7.26.0
         version: 7.26.0
@@ -875,7 +875,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       astro:
         specifier: ^5.1.6
-        version: 5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.1)
@@ -932,7 +932,7 @@ importers:
         version: 0.4.4
       astro:
         specifier: 5.1.7
-        version: 5.1.7(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 5.1.7(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
       postcss:
         specifier: ^8.5.1
         version: 8.5.1
@@ -971,7 +971,7 @@ importers:
         version: 0.4.4
       astro:
         specifier: ^4.16.18
-        version: 4.16.18(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)
+        version: 4.16.18(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)
       postcss-html:
         specifier: ^1.8.0
         version: 1.8.0
@@ -2884,6 +2884,11 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.31.0':
+    resolution: {integrity: sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.26.0':
     resolution: {integrity: sha512-YJa5Gy8mEZgz5JquFruhJODMq3lTHWLm1fOy+HIANquLzfIOzE9RA5ie3JjCdVb9r46qfAQY/l947V0zfGJ0OQ==}
     cpu: [arm64]
@@ -2891,6 +2896,11 @@ packages:
 
   '@rollup/rollup-android-arm64@4.27.4':
     resolution: {integrity: sha512-wzKRQXISyi9UdCVRqEd0H4cMpzvHYt1f/C3CoIjES6cG++RHKhrBj2+29nPF0IB5kpy9MS71vs07fvrNGAl/iA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.31.0':
+    resolution: {integrity: sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==}
     cpu: [arm64]
     os: [android]
 
@@ -2904,6 +2914,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.31.0':
+    resolution: {integrity: sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.26.0':
     resolution: {integrity: sha512-wbgkYDHcdWW+NqP2mnf2NOuEbOLzDblalrOWcPyY6+BRbVhliavon15UploG7PpBRQ2bZJnbmh8o3yLoBvDIHA==}
     cpu: [x64]
@@ -2911,6 +2926,11 @@ packages:
 
   '@rollup/rollup-darwin-x64@4.27.4':
     resolution: {integrity: sha512-o9bH2dbdgBDJaXWJCDTNDYa171ACUdzpxSZt+u/AAeQ20Nk5x+IhA+zsGmrQtpkLiumRJEYef68gcpn2ooXhSQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.31.0':
+    resolution: {integrity: sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -2924,6 +2944,11 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.31.0':
+    resolution: {integrity: sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.26.0':
     resolution: {integrity: sha512-A/jvfCZ55EYPsqeaAt/yDAG4q5tt1ZboWMHEvKAH9Zl92DWvMIbnZe/f/eOXze65aJaaKbL+YeM0Hz4kLQvdwg==}
     cpu: [x64]
@@ -2931,6 +2956,11 @@ packages:
 
   '@rollup/rollup-freebsd-x64@4.27.4':
     resolution: {integrity: sha512-wYcC5ycW2zvqtDYrE7deary2P2UFmSh85PUpAx+dwTCO9uw3sgzD6Gv9n5X4vLaQKsrfTSZZ7Z7uynQozPVvWA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.31.0':
+    resolution: {integrity: sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==}
     cpu: [x64]
     os: [freebsd]
 
@@ -2944,6 +2974,11 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.31.0':
+    resolution: {integrity: sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.26.0':
     resolution: {integrity: sha512-cwxiHZU1GAs+TMxvgPfUDtVZjdBdTsQwVnNlzRXC5QzIJ6nhfB4I1ahKoe9yPmoaA/Vhf7m9dB1chGPpDRdGXg==}
     cpu: [arm]
@@ -2951,6 +2986,11 @@ packages:
 
   '@rollup/rollup-linux-arm-musleabihf@4.27.4':
     resolution: {integrity: sha512-Vgdo4fpuphS9V24WOV+KwkCVJ72u7idTgQaBoLRD0UxBAWTF9GWurJO9YD9yh00BzbkhpeXtm6na+MvJU7Z73A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.31.0':
+    resolution: {integrity: sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==}
     cpu: [arm]
     os: [linux]
 
@@ -2964,6 +3004,11 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.31.0':
+    resolution: {integrity: sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.26.0':
     resolution: {integrity: sha512-eGkX7zzkNxvvS05ROzJ/cO/AKqNvR/7t1jA3VZDi2vRniLKwAWxUr85fH3NsvtxU5vnUUKFHKh8flIBdlo2b3Q==}
     cpu: [arm64]
@@ -2974,6 +3019,16 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-musl@4.31.0':
+    resolution: {integrity: sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.31.0':
+    resolution: {integrity: sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==}
+    cpu: [loong64]
+    os: [linux]
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.26.0':
     resolution: {integrity: sha512-Odp/lgHbW/mAqw/pU21goo5ruWsytP7/HCC/liOt0zcGG0llYWKrd10k9Fj0pdj3prQ63N5yQLCLiE7HTX+MYw==}
     cpu: [ppc64]
@@ -2981,6 +3036,11 @@ packages:
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.27.4':
     resolution: {integrity: sha512-FScrpHrO60hARyHh7s1zHE97u0KlT/RECzCKAdmI+LEoC1eDh/RDji9JgFqyO+wPDb86Oa/sXkily1+oi4FzJQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.31.0':
+    resolution: {integrity: sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==}
     cpu: [ppc64]
     os: [linux]
 
@@ -2994,6 +3054,11 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-gnu@4.31.0':
+    resolution: {integrity: sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-s390x-gnu@4.26.0':
     resolution: {integrity: sha512-YYcg8MkbN17fMbRMZuxwmxWqsmQufh3ZJFxFGoHjrE7bv0X+T6l3glcdzd7IKLiwhT+PZOJCblpnNlz1/C3kGQ==}
     cpu: [s390x]
@@ -3001,6 +3066,11 @@ packages:
 
   '@rollup/rollup-linux-s390x-gnu@4.27.4':
     resolution: {integrity: sha512-PFz+y2kb6tbh7m3A7nA9++eInGcDVZUACulf/KzDtovvdTizHpZaJty7Gp0lFwSQcrnebHOqxF1MaKZd7psVRg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.31.0':
+    resolution: {integrity: sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==}
     cpu: [s390x]
     os: [linux]
 
@@ -3014,6 +3084,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-gnu@4.31.0':
+    resolution: {integrity: sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-musl@4.26.0':
     resolution: {integrity: sha512-+HJD2lFS86qkeF8kNu0kALtifMpPCZU80HvwztIKnYwym3KnA1os6nsX4BGSTLtS2QVAGG1P3guRgsYyMA0Yhg==}
     cpu: [x64]
@@ -3021,6 +3096,11 @@ packages:
 
   '@rollup/rollup-linux-x64-musl@4.27.4':
     resolution: {integrity: sha512-5AeeAF1PB9TUzD+3cROzFTnAJAcVUGLuR8ng0E0WXGkYhp6RD6L+6szYVX+64Rs0r72019KHZS1ka1q+zU/wUw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.31.0':
+    resolution: {integrity: sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==}
     cpu: [x64]
     os: [linux]
 
@@ -3034,6 +3114,11 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rollup/rollup-win32-arm64-msvc@4.31.0':
+    resolution: {integrity: sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.26.0':
     resolution: {integrity: sha512-D4CxkazFKBfN1akAIY6ieyOqzoOoBV1OICxgUblWxff/pSjCA2khXlASUx7mK6W1oP4McqhgcCsu6QaLj3WMWg==}
     cpu: [ia32]
@@ -3044,6 +3129,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.31.0':
+    resolution: {integrity: sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.26.0':
     resolution: {integrity: sha512-2x8MO1rm4PGEP0xWbubJW5RtbNLk3puzAMaLQd3B3JHVw4KcHlmXcO+Wewx9zCoo7EUFiMlu/aZbCJ7VjMzAag==}
     cpu: [x64]
@@ -3051,6 +3141,11 @@ packages:
 
   '@rollup/rollup-win32-x64-msvc@4.27.4':
     resolution: {integrity: sha512-3j4jx1TppORdTAoBJRd+/wJRGCPC0ETWkXOecJ6PPZLj6SptXkrXcNqdj0oclbKML6FkQltdz7bBA3rUSirZug==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.31.0':
+    resolution: {integrity: sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==}
     cpu: [x64]
     os: [win32]
 
@@ -3081,6 +3176,9 @@ packages:
   '@shikijs/core@1.27.2':
     resolution: {integrity: sha512-ns1dokDr0KE1lQ9mWd4rqaBkhSApk0qGCK1+lOqwnkQSkVZ08UGqXj1Ef8dAcTMZNFkN6PSNjkL5TYNX7pyPbQ==}
 
+  '@shikijs/core@1.29.1':
+    resolution: {integrity: sha512-Mo1gGGkuOYjDu5H8YwzmOuly9vNr8KDVkqj9xiKhhhFS8jisAtDSEWB9hzqRHLVQgFdA310e8XRJcW4tYhRB2A==}
+
   '@shikijs/engine-javascript@1.23.1':
     resolution: {integrity: sha512-i/LdEwT5k3FVu07SiApRFwRcSJs5QM9+tod5vYCPig1Ywi8GR30zcujbxGQFJHwYD7A5BUqagi8o5KS+LEVgBg==}
 
@@ -3107,6 +3205,9 @@ packages:
 
   '@shikijs/engine-javascript@1.27.2':
     resolution: {integrity: sha512-0JB7U5vJc16NShBdxv9hSSJYSKX79+32O7F4oXIxJLdYfomyFvx4B982ackUI9ftO9T3WwagkiiD3nOxOOLiGA==}
+
+  '@shikijs/engine-javascript@1.29.1':
+    resolution: {integrity: sha512-Hpi8k9x77rCQ7F/7zxIOUruNkNidMyBnP5qAGbLFqg4kRrg1HZhkB8btib5EXbQWTtLb5gBHOdBwshk20njD7Q==}
 
   '@shikijs/engine-oniguruma@1.23.1':
     resolution: {integrity: sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==}
@@ -3135,6 +3236,9 @@ packages:
   '@shikijs/engine-oniguruma@1.27.2':
     resolution: {integrity: sha512-FZYKD1KN7srvpkz4lbGLOYWlyDU4Rd+2RtuKfABTkafAPOFr+J6umfIwY/TzOQqfNtWjL7SAwPAO0dcOraRLaQ==}
 
+  '@shikijs/engine-oniguruma@1.29.1':
+    resolution: {integrity: sha512-gSt2WhLNgEeLstcweQOSp+C+MhOpTsgdNXRqr3zP6M+BUBZ8Md9OU2BYwUYsALBxHza7hwaIWtFHjQ/aOOychw==}
+
   '@shikijs/langs@1.26.0':
     resolution: {integrity: sha512-Mr3NjEMhyjmiUefL8Ayd1GvPXpljh497NWlARln1REe/q3JlOHhaRFykAviprojwwMYt5bPHA0LbAw6v+C1ZWQ==}
 
@@ -3147,6 +3251,9 @@ packages:
   '@shikijs/langs@1.27.2':
     resolution: {integrity: sha512-MSrknKL0DbeXvhtSigMLIzjPOOQfvK7fsbcRv2NUUB0EvuTTomY8/U+lAkczYrXY2+dygKOapJKk8ScFYbtoNw==}
 
+  '@shikijs/langs@1.29.1':
+    resolution: {integrity: sha512-iERn4HlyuT044/FgrvLOaZgKVKf3PozjKjyV/RZ5GnlyYEAZFcgwHGkYboeBv2IybQG1KVS/e7VGgiAU4JY2Gw==}
+
   '@shikijs/themes@1.26.0':
     resolution: {integrity: sha512-LeJsFR0Xc4+bo6wQTcsdHaj1oCklkcmTiopv5mKjEjrVtvYV7fHfru//lx3bt0LR5SFC9KyCC9cvFs1HOdUjrg==}
 
@@ -3158,6 +3265,9 @@ packages:
 
   '@shikijs/themes@1.27.2':
     resolution: {integrity: sha512-Yw/uV7EijjWavIIZLoWneTAohcbBqEKj6XMX1bfMqO3llqTKsyXukPp1evf8qPqzUHY7ibauqEaQchhfi857mg==}
+
+  '@shikijs/themes@1.29.1':
+    resolution: {integrity: sha512-lb11zf72Vc9uxkl+aec2oW1HVTHJ2LtgZgumb4Rr6By3y/96VmlU44bkxEb8WBWH3RUtbqAJEN0jljD9cF7H7g==}
 
   '@shikijs/types@1.23.1':
     resolution: {integrity: sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==}
@@ -3185,6 +3295,9 @@ packages:
 
   '@shikijs/types@1.27.2':
     resolution: {integrity: sha512-DM9OWUyjmdYdnKDpaGB/GEn9XkToyK1tqxuqbmc5PV+5K8WjjwfygL3+cIvbkSw2v1ySwHDgqATq/+98pJ4Kyg==}
+
+  '@shikijs/types@1.29.1':
+    resolution: {integrity: sha512-aBqAuhYRp5vSir3Pc9+QPu9WESBOjUo03ao0IHLC4TyTioSsp/SkbAZSrIH4ghYYC1T1KTEpRSBa83bas4RnPA==}
 
   '@shikijs/vscode-textmate@10.0.1':
     resolution: {integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==}
@@ -3555,11 +3668,6 @@ packages:
     engines: {node: ^18.17.1 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
-  astro@5.0.0:
-    resolution: {integrity: sha512-hsDlZ8m8rHWDdvCi3TcgFT6vS2S4Wt33m9AUOPfLUZ1JkzchIKtviWbGFqJCu3LhlpnUHyP2AxujWVm+IBS6tw==}
-    engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
-    hasBin: true
-
   astro@5.0.3:
     resolution: {integrity: sha512-qpeN+POmmfAQu/XDXaI2CxkUgQFwH9uMUVaA1reV9rybzIbOVYc3E3BU5SkiP/W4BMUFPdJtyw6+/n/0AUv6rw==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -3607,6 +3715,11 @@ packages:
 
   astro@5.1.7:
     resolution: {integrity: sha512-hGYHtO+67ZWDl0TY9ysh2iBv2KOgcgvpFJaMGZvknqBjh6TGqrwtWldCsJr1CK57rK8ycpPwC3Bi5bPaBELMuw==}
+    engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
+    hasBin: true
+
+  astro@5.1.9:
+    resolution: {integrity: sha512-QB3MH7Ul3gEvmHXEfvPkGpTZyyB/TBKQbm0kTHpo0BTEB7BvaY+wrcWiGEJBVDpVdEAKY9fM3zrJ0c7hZSXVlw==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -4063,6 +4176,9 @@ packages:
 
   crossws@0.3.1:
     resolution: {integrity: sha512-HsZgeVYaG+b5zA+9PbIPGq4+J/CJynJuearykPsXx4V/eMhyQ5EDVg3Ak2FBZtVXCiOLu/U7IiwDHTr9MA+IKw==}
+
+  crossws@0.3.2:
+    resolution: {integrity: sha512-S2PpQHRcgYABOS2465b34wqTOn5dbLL+iSvyweJYGGFLDsKq88xrjDXUiEhfYkhWZq1HuS6of3okRHILbkrqxw==}
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
@@ -4910,6 +5026,9 @@ packages:
 
   h3@1.13.0:
     resolution: {integrity: sha512-vFEAu/yf8UMUcB4s43OaDaigcqpQd14yanmOsn+NcRX3/guSKncyE2rOYhq8RIchgJrPSs/QiIddnTTR1ddiAg==}
+
+  h3@1.14.0:
+    resolution: {integrity: sha512-ao22eiONdgelqcnknw0iD645qW0s9NnrJHr5OBz4WOMdBdycfSas1EQf1wXRsm+PcB2Yoj43pjBPwqIpJQTeWg==}
 
   harfbuzzjs@0.3.6:
     resolution: {integrity: sha512-dzf7y6NS8fiAIvPAL/VKwY8wx2HCzUB0vUfOo6h1J5UilFEEf7iYqFsvgwjHwvM3whbjfOMadNvQekU3KuRnWQ==}
@@ -5912,6 +6031,9 @@ packages:
   node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
 
+  node-fetch-native@1.6.6:
+    resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
+
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -6038,6 +6160,9 @@ packages:
   oniguruma-to-es@2.0.0:
     resolution: {integrity: sha512-pE7+9jQgomy10aK6BJKRNHj1Nth0YLOzb3iRuhlz4gRzNSBSd7hga6U8BE6o0SoSuSkqv+PPtt511Msd1Hkl0w==}
 
+  oniguruma-to-es@2.3.0:
+    resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
+
   opentype.js@1.3.4:
     resolution: {integrity: sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==}
     engines: {node: '>= 8.0.0'}
@@ -6089,6 +6214,10 @@ packages:
 
   p-queue@8.0.1:
     resolution: {integrity: sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==}
+    engines: {node: '>=18'}
+
+  p-queue@8.1.0:
+    resolution: {integrity: sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==}
     engines: {node: '>=18'}
 
   p-timeout@6.1.4:
@@ -6185,6 +6314,9 @@ packages:
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.2:
+    resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
 
   pdfjs@2.5.3:
     resolution: {integrity: sha512-XSFh7/znM7gJAVABFvrtIkxi6TcHyHUCYpwaRUv1h0ln2ZQel0s8nKgsvmo+D7IKkkXKEQNtMU/hdmF/MUeaHg==}
@@ -6950,6 +7082,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rollup@4.31.0:
+    resolution: {integrity: sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -7209,6 +7346,9 @@ packages:
 
   shiki@1.27.2:
     resolution: {integrity: sha512-QtA1C41oEVixKog+V8I3ia7jjGls7oCZ8Yul8vdHrVBga5uPoyTtMvFF4lMMXIyAZo5A5QbXq91bot2vA6Q+eQ==}
+
+  shiki@1.29.1:
+    resolution: {integrity: sha512-TghWKV9pJTd/N+IgAIVJtr0qZkB7FfFCUrrEJc0aRmZupo3D1OCVRknQWVRVA7AX/M0Ld7QfoAruPzr3CnUJuw==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -7729,8 +7869,8 @@ packages:
     resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
     engines: {node: '>=8'}
 
-  type-fest@4.32.0:
-    resolution: {integrity: sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==}
+  type-fest@4.33.0:
+    resolution: {integrity: sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==}
     engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
@@ -8050,6 +8190,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@3.0.4:
+    resolution: {integrity: sha512-7JZKEzcYV2Nx3u6rlvN8qdo3QV7Fxyt6hx+CCKz9fbWxdX5IvUOmTWEAxMrWxaiSf7CKGLJQ5rFu8prb/jBjOA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@5.4.11:
     resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -8079,6 +8224,77 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vite@5.4.14:
+    resolution: {integrity: sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vite@6.0.11:
+    resolution: {integrity: sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vite@6.0.3:
@@ -8802,13 +9018,13 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@12.1.0(@types/node@22.10.6)(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)':
+  '@astrojs/cloudflare@12.1.0(@types/node@22.10.6)(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.1
       '@astrojs/underscore-redirects': 0.4.0
       '@cloudflare/workers-types': 4.20241205.0
-      '@inox-tools/astro-when': 1.0.1(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))
-      astro: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      '@inox-tools/astro-when': 1.0.1(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))
+      astro: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       esbuild: 0.24.0
       estree-walker: 3.0.3
       magic-string: 0.30.15
@@ -8832,13 +9048,13 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@astrojs/cloudflare@12.1.0(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)':
+  '@astrojs/cloudflare@12.1.0(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.1
       '@astrojs/underscore-redirects': 0.4.0
       '@cloudflare/workers-types': 4.20241205.0
-      '@inox-tools/astro-when': 1.0.1(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))
-      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      '@inox-tools/astro-when': 1.0.1(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))
+      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       esbuild: 0.24.0
       estree-walker: 3.0.3
       magic-string: 0.30.15
@@ -8920,13 +9136,13 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@astrojs/markdoc@0.12.4(@types/react@19.0.2)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(react@19.0.0)':
+  '@astrojs/markdoc@0.12.4(@types/react@19.0.2)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(react@19.0.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.1
       '@astrojs/prism': 3.2.0
       '@markdoc/markdoc': 0.4.0(@types/react@19.0.2)(react@19.0.0)
-      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       esbuild: 0.21.5
       github-slugger: 2.0.0
       htmlparser2: 9.1.0
@@ -9021,7 +9237,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.1
       remark-smartypants: 3.0.2
-      shiki: 1.27.2
+      shiki: 1.29.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.0.0
@@ -9030,13 +9246,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/netlify@6.0.1(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)':
+  '@astrojs/netlify@6.0.1(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.1
       '@astrojs/underscore-redirects': 0.4.0
       '@netlify/functions': 2.8.2
-      '@vercel/nft': 0.27.10(rollup@4.27.4)
-      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      '@vercel/nft': 0.27.10(rollup@4.31.0)
+      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       esbuild: 0.24.2
       vite: 6.0.6(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -9162,10 +9378,10 @@ snapshots:
       fast-xml-parser: 4.5.1
       kleur: 4.1.5
 
-  '@astrojs/svelte@5.7.3(astro@4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2))(svelte@4.2.19)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0))':
+  '@astrojs/svelte@5.7.3(astro@4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2))(svelte@4.2.19)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0))
-      astro: 4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)
+      astro: 4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)
       svelte: 4.2.19
       svelte2tsx: 0.7.31(svelte@4.2.19)(typescript@5.7.2)
       typescript: 5.7.2
@@ -9173,10 +9389,10 @@ snapshots:
       - supports-color
       - vite
 
-  '@astrojs/svelte@7.0.1(@types/node@22.10.6)(astro@5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.7.1)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
+  '@astrojs/svelte@7.0.1(@types/node@22.10.6)(astro@5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.7.1)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.1(svelte@5.7.1)(vite@6.0.3(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
-      astro: 5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro: 5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       svelte: 5.7.1
       svelte2tsx: 0.7.28(svelte@5.7.1)(typescript@5.7.2)
       typescript: 5.7.2
@@ -9195,10 +9411,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@7.0.1(@types/node@22.10.6)(astro@5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.14.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
+  '@astrojs/svelte@7.0.1(@types/node@22.10.6)(astro@5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.14.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.1(svelte@5.14.0)(vite@6.0.3(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
-      astro: 5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro: 5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       svelte: 5.14.0
       svelte2tsx: 0.7.28(svelte@5.14.0)(typescript@5.7.2)
       typescript: 5.7.2
@@ -9217,10 +9433,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@7.0.1(@types/node@22.10.6)(astro@5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.15.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
+  '@astrojs/svelte@7.0.1(@types/node@22.10.6)(astro@5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.15.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.1(svelte@5.15.0)(vite@6.0.3(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
-      astro: 5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro: 5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       svelte: 5.15.0
       svelte2tsx: 0.7.28(svelte@5.15.0)(typescript@5.7.2)
       typescript: 5.7.2
@@ -9239,10 +9455,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.15.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
+  '@astrojs/svelte@7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.15.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.1(svelte@5.15.0)(vite@6.0.5(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
-      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       svelte: 5.15.0
       svelte2tsx: 0.7.31(svelte@5.15.0)(typescript@5.7.2)
       typescript: 5.7.2
@@ -9261,10 +9477,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.16.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
+  '@astrojs/svelte@7.0.2(@types/node@22.10.6)(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.16.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.1(svelte@5.16.0)(vite@6.0.5(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
-      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       svelte: 5.16.0
       svelte2tsx: 0.7.31(svelte@5.16.0)(typescript@5.7.2)
       typescript: 5.7.2
@@ -9283,10 +9499,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@7.0.3(@types/node@22.10.6)(astro@4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.17.3)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)':
+  '@astrojs/svelte@7.0.3(@types/node@22.10.6)(astro@4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.17.3)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.1(svelte@5.17.3)(vite@6.0.7(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
-      astro: 4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)
+      astro: 4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)
       svelte: 5.17.3
       svelte2tsx: 0.7.31(svelte@5.17.3)(typescript@5.7.3)
       typescript: 5.7.3
@@ -9305,10 +9521,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@7.0.3(@types/node@22.10.6)(astro@5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.17.4)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)':
+  '@astrojs/svelte@7.0.3(@types/node@22.10.6)(astro@5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(svelte@5.17.4)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.1(svelte@5.17.4)(vite@6.0.7(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
-      astro: 5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
+      astro: 5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
       svelte: 5.17.4
       svelte2tsx: 0.7.31(svelte@5.17.4)(typescript@5.7.3)
       typescript: 5.7.3
@@ -9330,7 +9546,7 @@ snapshots:
   '@astrojs/telemetry@3.1.0':
     dependencies:
       ci-info: 4.1.0
-      debug: 4.4.0
+      debug: 4.3.7
       dlv: 1.1.3
       dset: 3.1.4
       is-docker: 3.0.0
@@ -9517,7 +9733,7 @@ snapshots:
       '@babel/parser': 7.26.5
       '@babel/template': 7.25.9
       '@babel/types': 7.26.5
-      debug: 4.4.0
+      debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10509,18 +10725,18 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@inox-tools/astro-when@1.0.1(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))':
+  '@inox-tools/astro-when@1.0.1(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))':
     dependencies:
-      astro: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
-      astro-integration-kit: 0.17.0(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))
+      astro: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro-integration-kit: 0.17.0(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
-  '@inox-tools/astro-when@1.0.1(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))':
+  '@inox-tools/astro-when@1.0.1(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))':
     dependencies:
-      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
-      astro-integration-kit: 0.17.0(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))
+      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro-integration-kit: 0.17.0(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0))
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
@@ -10810,26 +11026,29 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
-  '@rollup/pluginutils@5.1.3(rollup@4.27.4)':
+  '@rollup/pluginutils@5.1.3(rollup@4.31.0)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.27.4
+      rollup: 4.31.0
 
-  '@rollup/pluginutils@5.1.4(rollup@4.27.4)':
+  '@rollup/pluginutils@5.1.4(rollup@4.31.0)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.27.4
+      rollup: 4.31.0
 
   '@rollup/rollup-android-arm-eabi@4.26.0':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.27.4':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.31.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.26.0':
@@ -10838,10 +11057,16 @@ snapshots:
   '@rollup/rollup-android-arm64@4.27.4':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.31.0':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.26.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.27.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.31.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.26.0':
@@ -10850,10 +11075,16 @@ snapshots:
   '@rollup/rollup-darwin-x64@4.27.4':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.31.0':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.26.0':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.27.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.31.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.26.0':
@@ -10862,10 +11093,16 @@ snapshots:
   '@rollup/rollup-freebsd-x64@4.27.4':
     optional: true
 
+  '@rollup/rollup-freebsd-x64@4.31.0':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.26.0':
@@ -10874,10 +11111,16 @@ snapshots:
   '@rollup/rollup-linux-arm-musleabihf@4.27.4':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.31.0':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.26.0':
@@ -10886,10 +11129,19 @@ snapshots:
   '@rollup/rollup-linux-arm64-musl@4.27.4':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.31.0':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.31.0':
+    optional: true
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.26.0':
@@ -10898,10 +11150,16 @@ snapshots:
   '@rollup/rollup-linux-riscv64-gnu@4.27.4':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.31.0':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.26.0':
@@ -10910,10 +11168,16 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.27.4':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.31.0':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.31.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.26.0':
@@ -10922,16 +11186,25 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.27.4':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.31.0':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.26.0':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.27.4':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.31.0':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.26.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.27.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.31.0':
     optional: true
 
   '@shikijs/core@1.23.1':
@@ -11015,6 +11288,15 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.4
 
+  '@shikijs/core@1.29.1':
+    dependencies:
+      '@shikijs/engine-javascript': 1.29.1
+      '@shikijs/engine-oniguruma': 1.29.1
+      '@shikijs/types': 1.29.1
+      '@shikijs/vscode-textmate': 10.0.1
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.4
+
   '@shikijs/engine-javascript@1.23.1':
     dependencies:
       '@shikijs/types': 1.23.1
@@ -11069,6 +11351,12 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.1
       oniguruma-to-es: 2.0.0
 
+  '@shikijs/engine-javascript@1.29.1':
+    dependencies:
+      '@shikijs/types': 1.29.1
+      '@shikijs/vscode-textmate': 10.0.1
+      oniguruma-to-es: 2.3.0
+
   '@shikijs/engine-oniguruma@1.23.1':
     dependencies:
       '@shikijs/types': 1.23.1
@@ -11114,6 +11402,11 @@ snapshots:
       '@shikijs/types': 1.27.2
       '@shikijs/vscode-textmate': 10.0.1
 
+  '@shikijs/engine-oniguruma@1.29.1':
+    dependencies:
+      '@shikijs/types': 1.29.1
+      '@shikijs/vscode-textmate': 10.0.1
+
   '@shikijs/langs@1.26.0':
     dependencies:
       '@shikijs/types': 1.26.0
@@ -11130,6 +11423,10 @@ snapshots:
     dependencies:
       '@shikijs/types': 1.27.2
 
+  '@shikijs/langs@1.29.1':
+    dependencies:
+      '@shikijs/types': 1.29.1
+
   '@shikijs/themes@1.26.0':
     dependencies:
       '@shikijs/types': 1.26.0
@@ -11145,6 +11442,10 @@ snapshots:
   '@shikijs/themes@1.27.2':
     dependencies:
       '@shikijs/types': 1.27.2
+
+  '@shikijs/themes@1.29.1':
+    dependencies:
+      '@shikijs/types': 1.29.1
 
   '@shikijs/types@1.23.1':
     dependencies:
@@ -11187,6 +11488,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/types@1.27.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.1
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@1.29.1':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.1
       '@types/hast': 3.0.4
@@ -11573,7 +11879,7 @@ snapshots:
       find-up: 5.0.0
       javascript-stringify: 2.1.0
       mlly: 1.7.3
-      vite: 5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)
+      vite: 5.4.14(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)
       vite-node: 1.6.0(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -11605,10 +11911,10 @@ snapshots:
       - supports-color
       - terser
 
-  '@vercel/nft@0.27.10(rollup@4.27.4)':
+  '@vercel/nft@0.27.10(rollup@4.31.0)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.0-rc.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
       acorn: 8.14.0
       acorn-import-attributes: 1.9.5(acorn@8.14.0)
       async-sema: 3.1.1
@@ -11896,19 +12202,19 @@ snapshots:
       - debug
       - supports-color
 
-  astro-integration-kit@0.17.0(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)):
+  astro-integration-kit@0.17.0(astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)):
     dependencies:
-      astro: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro: 5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       pathe: 1.1.2
       recast: 0.23.9
 
-  astro-integration-kit@0.17.0(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)):
+  astro-integration-kit@0.17.0(astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)):
     dependencies:
-      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
+      astro: 5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0)
       pathe: 1.1.2
       recast: 0.23.9
 
-  astro@4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2):
+  astro@4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.1
@@ -11918,7 +12224,7 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/types': 7.26.3
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       '@types/babel__core': 7.20.5
       '@types/cookie': 0.6.0
       acorn: 8.14.0
@@ -11987,7 +12293,7 @@ snapshots:
       - terser
       - typescript
 
-  astro@4.16.17(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3):
+  astro@4.16.17(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.1
@@ -11997,7 +12303,7 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/types': 7.26.3
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       '@types/babel__core': 7.20.5
       '@types/cookie': 0.6.0
       acorn: 8.14.0
@@ -12066,7 +12372,7 @@ snapshots:
       - terser
       - typescript
 
-  astro@4.16.18(@types/node@22.10.6)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3):
+  astro@4.16.18(@types/node@22.10.6)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.1
@@ -12076,7 +12382,7 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/types': 7.26.5
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
       '@types/babel__core': 7.20.5
       '@types/cookie': 0.6.0
       acorn: 8.14.0
@@ -12145,92 +12451,14 @@ snapshots:
       - terser
       - typescript
 
-  astro@5.0.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
+  astro@5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.0
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
-      '@types/cookie': 0.6.0
-      acorn: 8.14.0
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      boxen: 8.0.1
-      ci-info: 4.1.0
-      clsx: 2.1.1
-      common-ancestor-path: 1.0.1
-      cookie: 0.7.2
-      cssesc: 3.0.0
-      debug: 4.3.7
-      deterministic-object-hash: 2.0.2
-      devalue: 5.1.1
-      diff: 5.2.0
-      dlv: 1.1.3
-      dset: 3.1.4
-      es-module-lexer: 1.5.4
-      esbuild: 0.21.5
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      flattie: 1.1.1
-      github-slugger: 2.0.0
-      html-escaper: 3.0.3
-      http-cache-semantics: 4.1.1
-      js-yaml: 4.1.0
-      kleur: 4.1.5
-      magic-string: 0.30.14
-      magicast: 0.3.5
-      micromatch: 4.0.8
-      mrmime: 2.0.0
-      neotraverse: 0.6.18
-      p-limit: 6.1.0
-      p-queue: 8.0.1
-      preferred-pm: 4.0.0
-      prompts: 2.4.2
-      rehype: 13.0.2
-      semver: 7.6.3
-      shiki: 1.23.1
-      tinyexec: 0.3.1
-      tsconfck: 3.1.4(typescript@5.7.2)
-      ultrahtml: 1.5.3
-      unist-util-visit: 5.0.0
-      vfile: 6.0.3
-      vite: 6.0.7(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
-      vitefu: 1.0.4(vite@6.0.7(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
-      which-pm: 3.0.0
-      xxhash-wasm: 1.1.0
-      yargs-parser: 21.1.1
-      yocto-spinner: 0.1.1
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.5(zod@3.23.8)
-      zod-to-ts: 1.2.0(typescript@5.7.2)(zod@3.23.8)
-    optionalDependencies:
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - rollup
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - yaml
-
-  astro@5.0.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
-    dependencies:
-      '@astrojs/compiler': 2.10.3
-      '@astrojs/internal-helpers': 0.4.2
-      '@astrojs/markdown-remark': 6.0.0
-      '@astrojs/telemetry': 3.2.0
-      '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -12301,14 +12529,14 @@ snapshots:
       - typescript
       - yaml
 
-  astro@5.0.4(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
+  astro@5.0.4(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.1
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -12379,14 +12607,14 @@ snapshots:
       - typescript
       - yaml
 
-  astro@5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
+  astro@5.0.5(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.1
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -12457,14 +12685,14 @@ snapshots:
       - typescript
       - yaml
 
-  astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
+  astro@5.0.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.1
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -12535,14 +12763,14 @@ snapshots:
       - typescript
       - yaml
 
-  astro@5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
+  astro@5.1.0(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.1
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -12632,14 +12860,14 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
+  astro@5.1.1(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.1
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -12729,14 +12957,14 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@5.1.2(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
+  astro@5.1.2(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.1
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -12826,14 +13054,14 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@5.1.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
+  astro@5.1.3(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.1
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -12923,14 +13151,14 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0):
+  astro@5.1.6(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.1
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -13020,14 +13248,14 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@5.1.7(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.27.4)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0):
+  astro@5.1.7(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/markdown-remark': 6.0.2
       '@astrojs/telemetry': 3.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
       '@types/cookie': 0.6.0
       acorn: 8.14.0
       aria-query: 5.3.2
@@ -13074,6 +13302,103 @@ snapshots:
       vfile: 6.0.3
       vite: 6.0.7(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
       vitefu: 1.0.5(vite@6.0.7(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
+      which-pm: 3.0.0
+      xxhash-wasm: 1.1.0
+      yargs-parser: 21.1.1
+      yocto-spinner: 0.1.2
+      zod: 3.24.1
+      zod-to-json-schema: 3.24.1(zod@3.24.1)
+      zod-to-ts: 1.2.0(typescript@5.7.3)(zod@3.24.1)
+    optionalDependencies:
+      sharp: 0.33.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - lightningcss
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - yaml
+
+  astro@5.1.9(@types/node@22.10.6)(jiti@2.4.1)(rollup@4.31.0)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0):
+    dependencies:
+      '@astrojs/compiler': 2.10.3
+      '@astrojs/internal-helpers': 0.4.2
+      '@astrojs/markdown-remark': 6.0.2
+      '@astrojs/telemetry': 3.2.0
+      '@oslojs/encoding': 1.1.0
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
+      '@types/cookie': 0.6.0
+      acorn: 8.14.0
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      boxen: 8.0.1
+      ci-info: 4.1.0
+      clsx: 2.1.1
+      common-ancestor-path: 1.0.1
+      cookie: 0.7.2
+      cssesc: 3.0.0
+      debug: 4.4.0
+      deterministic-object-hash: 2.0.2
+      devalue: 5.1.1
+      diff: 5.2.0
+      dlv: 1.1.3
+      dset: 3.1.4
+      es-module-lexer: 1.6.0
+      esbuild: 0.24.2
+      estree-walker: 3.0.3
+      fast-glob: 3.3.3
+      flattie: 1.1.1
+      github-slugger: 2.0.0
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.1.1
+      js-yaml: 4.1.0
+      kleur: 4.1.5
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      micromatch: 4.0.8
+      mrmime: 2.0.0
+      neotraverse: 0.6.18
+      p-limit: 6.2.0
+      p-queue: 8.1.0
+      preferred-pm: 4.0.0
+      prompts: 2.4.2
+      rehype: 13.0.2
+      semver: 7.6.3
+      shiki: 1.29.1
+      tinyexec: 0.3.2
+      tsconfck: 3.1.4(typescript@5.7.3)
+      ultrahtml: 1.5.3
+      unist-util-visit: 5.0.0
+      unstorage: 1.14.4
+      vfile: 6.0.3
+      vite: 6.0.11(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
+      vitefu: 1.0.5(vite@6.0.11(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0))
       which-pm: 3.0.0
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -13222,7 +13547,7 @@ snapshots:
       chalk: 5.4.1
       cli-boxes: 3.0.0
       string-width: 7.2.0
-      type-fest: 4.32.0
+      type-fest: 4.33.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
 
@@ -13622,6 +13947,10 @@ snapshots:
       which: 2.0.2
 
   crossws@0.3.1:
+    dependencies:
+      uncrypto: 0.1.3
+
+  crossws@0.3.2:
     dependencies:
       uncrypto: 0.1.3
 
@@ -14710,6 +15039,19 @@ snapshots:
       uncrypto: 0.1.3
       unenv: 1.10.0
 
+  h3@1.14.0:
+    dependencies:
+      cookie-es: 1.2.2
+      crossws: 0.3.2
+      defu: 6.1.4
+      destr: 2.0.3
+      iron-webcrypto: 1.2.1
+      ohash: 1.1.4
+      radix3: 1.1.2
+      ufo: 1.5.4
+      uncrypto: 0.1.3
+      unenv: 1.10.0
+
   harfbuzzjs@0.3.6: {}
 
   harfbuzzjs@0.4.4: {}
@@ -15726,7 +16068,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.0
+      debug: 4.3.7
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
@@ -15906,6 +16248,8 @@ snapshots:
 
   node-fetch-native@1.6.4: {}
 
+  node-fetch-native@1.6.6: {}
+
   node-fetch@2.6.7:
     dependencies:
       whatwg-url: 5.0.0
@@ -16041,6 +16385,12 @@ snapshots:
       regex: 5.1.1
       regex-recursion: 5.1.1
 
+  oniguruma-to-es@2.3.0:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 5.1.1
+      regex-recursion: 5.1.1
+
   opentype.js@1.3.4:
     dependencies:
       string.prototype.codepointat: 0.2.1
@@ -16106,6 +16456,11 @@ snapshots:
       p-limit: 4.0.0
 
   p-queue@8.0.1:
+    dependencies:
+      eventemitter3: 5.0.1
+      p-timeout: 6.1.4
+
+  p-queue@8.1.0:
     dependencies:
       eventemitter3: 5.0.1
       p-timeout: 6.1.4
@@ -16194,6 +16549,8 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
+
+  pathe@2.0.2: {}
 
   pdfjs@2.5.3:
     dependencies:
@@ -17144,6 +17501,31 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.27.4
       fsevents: 2.3.3
 
+  rollup@4.31.0:
+    dependencies:
+      '@types/estree': 1.0.6
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.31.0
+      '@rollup/rollup-android-arm64': 4.31.0
+      '@rollup/rollup-darwin-arm64': 4.31.0
+      '@rollup/rollup-darwin-x64': 4.31.0
+      '@rollup/rollup-freebsd-arm64': 4.31.0
+      '@rollup/rollup-freebsd-x64': 4.31.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.31.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.31.0
+      '@rollup/rollup-linux-arm64-gnu': 4.31.0
+      '@rollup/rollup-linux-arm64-musl': 4.31.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.31.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.31.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.31.0
+      '@rollup/rollup-linux-s390x-gnu': 4.31.0
+      '@rollup/rollup-linux-x64-gnu': 4.31.0
+      '@rollup/rollup-linux-x64-musl': 4.31.0
+      '@rollup/rollup-win32-arm64-msvc': 4.31.0
+      '@rollup/rollup-win32-ia32-msvc': 4.31.0
+      '@rollup/rollup-win32-x64-msvc': 4.31.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -17467,6 +17849,17 @@ snapshots:
       '@shikijs/langs': 1.27.2
       '@shikijs/themes': 1.27.2
       '@shikijs/types': 1.27.2
+      '@shikijs/vscode-textmate': 10.0.1
+      '@types/hast': 3.0.4
+
+  shiki@1.29.1:
+    dependencies:
+      '@shikijs/core': 1.29.1
+      '@shikijs/engine-javascript': 1.29.1
+      '@shikijs/engine-oniguruma': 1.29.1
+      '@shikijs/langs': 1.29.1
+      '@shikijs/themes': 1.29.1
+      '@shikijs/types': 1.29.1
       '@shikijs/vscode-textmate': 10.0.1
       '@types/hast': 3.0.4
 
@@ -18419,7 +18812,7 @@ snapshots:
 
   type-fest@0.6.0: {}
 
-  type-fest@4.32.0: {}
+  type-fest@4.33.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -18602,9 +18995,9 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 3.6.0
       destr: 2.0.3
-      h3: 1.13.0
+      h3: 1.14.0
       lru-cache: 10.4.3
-      node-fetch-native: 1.6.4
+      node-fetch-native: 1.6.6
       ofetch: 1.4.1
       ufo: 1.5.4
 
@@ -18677,9 +19070,9 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-imagetools@7.0.5(rollup@4.27.4):
+  vite-imagetools@7.0.5(rollup@4.31.0):
     dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
       imagetools-core: 7.0.2
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -18691,7 +19084,7 @@ snapshots:
       debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)
+      vite: 5.4.14(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18706,10 +19099,10 @@ snapshots:
   vite-node@2.1.8(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7
-      es-module-lexer: 1.5.4
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)
+      vite: 5.4.14(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18720,6 +19113,27 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-node@3.0.4(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.2
+      vite: 6.0.11(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite@5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0):
     dependencies:
@@ -18732,6 +19146,32 @@ snapshots:
       sass: 1.83.0
       sass-embedded: 1.83.0
       terser: 5.37.0
+
+  vite@5.4.14(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.1
+      rollup: 4.31.0
+    optionalDependencies:
+      '@types/node': 22.10.6
+      fsevents: 2.3.3
+      sass: 1.83.0
+      sass-embedded: 1.83.0
+      terser: 5.37.0
+
+  vite@6.0.11(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0):
+    dependencies:
+      esbuild: 0.24.2
+      postcss: 8.5.1
+      rollup: 4.31.0
+    optionalDependencies:
+      '@types/node': 22.10.6
+      fsevents: 2.3.3
+      jiti: 2.4.1
+      sass: 1.83.0
+      sass-embedded: 1.83.0
+      terser: 5.37.0
+      yaml: 2.7.0
 
   vite@6.0.3(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0):
     dependencies:
@@ -18830,6 +19270,10 @@ snapshots:
   vitefu@1.0.5(vite@5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)):
     optionalDependencies:
       vite: 5.4.11(@types/node@22.10.6)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)
+
+  vitefu@1.0.5(vite@6.0.11(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)):
+    optionalDependencies:
+      vite: 6.0.11(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)
 
   vitefu@1.0.5(vite@6.0.3(@types/node@22.10.6)(jiti@2.4.1)(sass-embedded@1.83.0)(sass@1.83.0)(terser@5.37.0)(yaml@2.7.0)):
     optionalDependencies:


### PR DESCRIPTION
# Description

Update dependencies for astro-capsize-font-fallbacks demo:

┌──────────────────────────────┬─────────┬─────────┬──────────────────────────────┐
│ Package │ From │ To │ Dependents │
├──────────────────────────────┼─────────┼─────────┼──────────────────────────────┤
│ typescript (dev) │ 5.7.2 │ 5.7.3 │ astro-capsize-font-fallbacks │
├──────────────────────────────┼─────────┼─────────┼──────────────────────────────┤
│ astro │ 5.0.0 │ 5.1.9 │ astro-capsize-font-fallbacks │
├──────────────────────────────┼─────────┼─────────┼──────────────────────────────┤
│ postcss-html │ 1.7.0 │ 1.8.0 │ astro-capsize-font-fallbacks │
├──────────────────────────────┼─────────┼─────────┼──────────────────────────────┤
│ stylelint │ 16.11.0 │ 16.13.2 │ astro-capsize-font-fallbacks │
├──────────────────────────────┼─────────┼─────────┼──────────────────────────────┤
│ stylelint-config-recommended │ 14.0.1 │ 15.0.0 │ astro-capsize-font-fallbacks │
├──────────────────────────────┼─────────┼─────────┼──────────────────────────────┤
│ stylelint-config-standard │ 36.0.1 │ 37.0.0 │ astro-capsize-font-fallbacks │
├──────────────────────────────┼─────────┼─────────┼──────────────────────────────┤
│ vite-node (dev) │ 2.1.8 │ 3.0.4 │ astro-capsize-font-fallbacks │
└──────────────────────────────┴─────────┴─────────┴──────────────────────────────┘

## Type of change

- [x] Dependency update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
